### PR TITLE
Temporarily disable box servant requirement if set

### DIFF
--- a/src/level.ts
+++ b/src/level.ts
@@ -44,6 +44,7 @@ import {
   uneffect,
   Witchess,
   withProperties,
+  withProperty,
 } from "libram";
 
 const levellingComplete = myLevel() >= 13 && get("_neverendingPartyFreeTurns") >= 10;
@@ -249,7 +250,7 @@ const Level: CSQuest = {
       ready: () => have(sauceFruit),
       do: (): void => {
         if (!have(saucePotion)) {
-          create(1, saucePotion);
+          withProperty("requireBoxServants", false, () => create(1, saucePotion));
         }
         if (have(saucePotion)) {
           use(1, saucePotion);


### PR DESCRIPTION
I occasionally set this when doing a run semi-manually and noticed there are problems here if it is set. It would be more appropriate in some sort of global properties thing but I'm not sure how to do that in grimoire
