### PR TITLE
Added support for imported taffy in weapon.ts

### DIFF
--- a/src/weapon.ts
+++ b/src/weapon.ts
@@ -70,6 +70,7 @@ const Weapon: CSQuest = {
     skillTask($effect`Frenzied, Bloody`),
     potionTask($item`LOV Elixir #3`),
     potionTask($item`vial of hamethyst juice`),
+    potionTask($item`imported taffy`),
     beachTask($effect`Lack of Body-Building`),
     songTask($effect`Jackasses' Symphony of Destruction`, $effect`The Sonata of Sneakiness`),
     {


### PR DESCRIPTION
The code change is simple, just adding an attempt to use "imported taffy" to the weapon test. 

I've never tried to submit a change via github before, so hopefully I'm executing the workflow correctly. Fingers crossed.